### PR TITLE
Day 1/2/3 - FILE_filetypes.yar

### DIFF
--- a/petermstewart/FILE_filetypes.yar
+++ b/petermstewart/FILE_filetypes.yar
@@ -8,3 +8,14 @@ rule file_pe_header {
     condition:
         uint16(0) == 0x5a4d
 }
+
+rule file_elf_header {
+    meta:
+        description = "Matches ELF file \x7fELF header as uint32"
+        last_modified = "2024-01-02"
+        author = "@petermstewart"
+        DaysofYara = "2/100"
+
+    condition:
+        uint32(0) == 0x464c457f
+}

--- a/petermstewart/FILE_filetypes.yar
+++ b/petermstewart/FILE_filetypes.yar
@@ -1,0 +1,10 @@
+rule file_pe_header {
+    meta:
+        description = "Finds PE file MZ header as uint16"
+        last_modified = "2024-01-01"
+        author = "@petermstewart"
+        DaysofYara = "1/100"
+
+    condition:
+        uint16(0) == 0x5a4d
+}

--- a/petermstewart/FILE_filetypes.yar
+++ b/petermstewart/FILE_filetypes.yar
@@ -19,3 +19,19 @@ rule file_elf_header {
     condition:
         uint32(0) == 0x464c457f
 }
+
+rule file_macho_header {
+    meta:
+        description = "Matches Mach-O file headers as uint32"
+        last_modified = "2024-01-03"
+        author = "@petermstewart"
+        DaysofYara = "3/100"
+
+    condition:
+        uint32(0) == 0xfeedface or  //MH_MAGIC
+        uint32(0) == 0xcefaedfe or  //MH_CIGAM
+        uint32(0) == 0xfeedfacf or  //MH_MAGIC_64
+        uint32(0) == 0xcffaedfe or  //MH_CIGAM_64
+        uint32(0) == 0xcafebabe or  //FAT_MAGIC
+        uint32(0) == 0xbebafeca     //FAT_CIGAM
+}


### PR DESCRIPTION
Rules to identify PE, ELF, and MachO binaries.