### PR TITLE
LevelDB file format

### DIFF
--- a/larsborn/Day_004.yara
+++ b/larsborn/Day_004.yara
@@ -1,0 +1,12 @@
+rule fileformat_leveldb {
+    meta:
+        description = "LeveDB database format"
+        author = "@larsborn"
+        created_at = "2022-01-15"
+        reference = "https://github.com/google/leveldb/blob/master/doc/table_format.md"
+
+        DaysofYARA = "4/100"
+    condition:
+        // file ends in { 57 fb 80 8b 24 75 47 db }
+        uint32(filesize - 8) == 0x8b80fb57 and uint32(filesize - 4) == 0xdb477524
+}


### PR DESCRIPTION
Todays rule is unrelated to malware. It's for the files used by LevelDB, an open-source on-disk key-value store written by Google. I was surprised how much software is using that format and you can be too: just scan your drive with that rule and get a list. Things like the following will show up: Discord, Github Desktop, MS Teams, Obsidian, Postman, Signal, Slack, Spotify, or Steam. Also every Chrome-based browser uses it (as a backend of IndexedDB according to Wikipedia). This not only includes _tons_ of browsers but also things like the browser-based OBS plugins for example.

Anyway, we were talking about YARA: I know that the rule can be written in a more readable fashion (by locating the `{ 57 fb 80 8b 24 75 47 db }` sequence at `filesize - 8`) but writing it like above, without any `strings:` section, has some performance benefits.
