### PR TITLE
deflate copyright string

### DIFF
--- a/larsborn/Day_005.yara
+++ b/larsborn/Day_005.yara
@@ -1,0 +1,14 @@
+rule deflate_copyright {
+    meta:
+        description = "Copyright string of the deflate algorithm"
+        author = "@larsborn"
+        created_at = "2023-05-09"
+        reference = "https://github.com/commontk/zlib/blob/master/deflate.c"
+        example_hash_01 = "fbe103fac45abe4e3638055a3cac5e7009166f626cf2d3049fb46f3b53c1057f"
+
+        DaysofYARA = "5/100"
+    strings:
+        $ = " deflate 1.2.3 Copyright 1995-2005 Jean-loup Gailly "
+    condition:
+        all of them
+}


### PR DESCRIPTION
For me, a first step during reverse engineering is to scan the target sample with a "good" corpus of YARA rules. The "good" here means many different things: some rules in the corpus just try to classify the malware family, others are merely there for informational purposes, say, by classifying file types, yet others implement heuristics for general maliciousnes, say "a base64 encoded .zip file inside a PE resource". But in my experience, a very important class of YARA rules are those that give good entry points for bottom-up analysis. And one sub-class are copyright strings. And here you have one of them.