### PR TITLE
Resource name of compiled AutoHotkey (.ahk) scripts

### DIFF
--- a/larsborn/Day_008.yara
+++ b/larsborn/Day_008.yara
@@ -1,0 +1,14 @@
+import "pe"
+
+rule AutoHotkey_ResourceName {
+    meta:
+        description = "Resource name of compiled AutoHotkey (.ahk) scripts"
+        author = "@larsborn"
+        created_at = "2024-01-10"
+        reference = "https://www.autohotkey.com/docs/v1/Scripts.htm#ahk2exe-base"
+
+        DaysofYARA = "8/100"
+    condition:
+        for any i in (0..pe.number_of_resources - 1):
+            (pe.resources[i].name_string == ">\x00A\x00U\x00T\x00O\x00H\x00O\x00T\x00K\x00E\x00Y\x00 \x00S\x00C\x00R\x00I\x00P\x00T\x00<\x00")
+}


### PR DESCRIPTION
AutoHotkey (AHK) is a scripting language for Windows that allows remapping of keys in an extremely simple fashion but on the other hand is also Turing complete. The default installation comes with support for "compiling" script files into standalone executables. There is no "real" compilation going on though: the script is just shipped in a PE resource along the default AHK interpreter. This rule matches on this particular resource name. Note that a resourceful malware author might be able to change that resource name, and they would also write their malware in AutoHotkey ;-).