### PR TITLE
RAR archives

### DIFF
--- a/larsborn/Day_010.yara
+++ b/larsborn/Day_010.yara
@@ -1,0 +1,16 @@
+rule Day_10 {
+    meta:
+        description = "RAR archive"
+        author = "@larsborn"
+        date = "2024-01-14"
+        reference = "https://en.wikipedia.org/wiki/RAR_(file_format)"
+        example_hash_01 = "00001fb5831c83b6a6a271914a3ea95ca6ab4f9d65417ce8c4bedcf9d961355c"
+        example_hash_02 = "0002e2c391cc602123c69144f792fc25d6ee7584320763aa054ead3efad91028"
+
+        DaysofYARA = "10/100"
+    condition:
+        (uint32be(0) == 0x52617221) and (
+            (uint16be(4) == 0x1A07 and uint16be(5) == 0x0700) // RAR 1.5 to 4.0
+            or (uint32be(4) == 0x1a070100) // RAR 5+
+        ) and (filesize > 20)
+}


### PR DESCRIPTION
A generic rule leveraging magic values from the different RAR archive versions. I discovered a new (to me at least) way to work around the problem that there's no function to match on a single byte within the condition only. Let me go on a rant why that's important:

While it is possible to define a string `$s1 = { 00 }` and then do `$s1 at 6` in the condition, this is abyssmal for performance. That's caused by how YARA is implemented: for every string, YARA first collects all matches (including their positions) and hence needs to allocate some memory for every match. Only then will it evaluate the condition and realize that it could have recorded the position at only one place. This is taken to the extreme if you use your rules to scan, say, a memory dump: Those are quite big _and_ have tons of zero bytes. Which will probably lead to YARA going out of memory.

One way around this is to use the `uint*` functions in the condition instead of strings. So instead of a string `$s1 = { 52 61 72 21 }` and then doing `$s1 at 0` in the condition, you can just do `uint32be(0) == 0x52617221` (thank @glesnewich again for telling me the `be` variants exist). But YARA does not have a function to match only one single byte (like ... `uint8`). And up until now I thought that this means that you can't match on magic values with an uneven lenght for example.

So let's use the RAR version 1.5-4 magic value `{ 52 61 72 21 1A 07 00}` as an example: `uint32be(0) == 0x52617221 and uint16be(4) == 0x1A07 and uint8be(6) == 0x00`. But, again, there no such thing as `uint8be`. Today I realized that you only need to _cover_ the bytes in question, not really have those covering components disjoint: so instead of the impossible `uint16be(4) == 0x1A07 and uint8be(6) == 0x00` part, you can do the very possible `uint16be(4) == 0x1A07 and uint16be(5) == 0x0700` (covering the byte `0x70` at position 5 with two of the conditions).