### PR TITLE
Email with ZIP file attachment

### DIFF
--- a/larsborn/Day_016.yara
+++ b/larsborn/Day_016.yara
@@ -1,0 +1,23 @@
+rule EmailWithZipAttachment {
+    meta:
+        description = "Some common email headers together with base64 encoded start of a ZIP file"
+        author = "@larsborn"
+        date = "2024-02-06"
+        reference = "https://en.wikipedia.org/wiki/Base64"
+        example_hash = "941e4a04ea1ffca986f3ae78f7d0a9bc5483464a679e6ea49a5f4ab8e7e92c03"
+
+        DaysofYARA = "16/100"
+    strings:
+        $email_headers_01 = "Received: "
+        $email_headers_02 = "From: "
+        $email_headers_03 = "Date: "
+        $email_headers_04 = "Subject: "
+        $email_headers_05 = "To: "
+        $attachment_headers_01 = "Content-Type: text/html; "
+        $attachment_headers_02 = "Content-Type: application/octet-stream; name="
+        $attachment_headers_03 = "Content-Disposition: attachment; filename="
+        $attachment_headers_04 = "Content-Transfer-Encoding: base64"
+        $base64_zip_attachment = { 0d 0a 0d 0a 55 45 73 44 42 }
+    condition:
+        all of them
+}


### PR DESCRIPTION
Last year, I "toured the nation" trying to explain threat hunting in the context of malware analysis to people working in IT in general and not (yet) in the field of cyber security. On that note, thanks to @kielux@mastodon.social, @fachschaft_info@toot.kif.rocks, and https://www.h-brs.de/ for having me. For my talk, I analyzed a simple drop chain starting with an email with a password-protected attachment, delivering a polyglot JS/Batch file, ultimately delivering StrelaStealer. I'll invest a couple of DaysOfYARA into covering that drop-chain.

And we start off with a generic rule for emails with a ZIP file attachment. I'm using what I tend to call the "base64 trick" here: Emails use base64 to encode binary attachments into printable text and we here want to match on the first 4 bytes of the ZIP file — 50 4b 03 04 — but in base64 encoded form. In base64 encoding, 6 bit are mapped to 1 character in the output alphabet (i.e. 24 bit — or 3 byte — are mapped to 4 characters — or 4 byte). Apart from that, the order is roughly the same in input and output. If you don't believe this babbling, here is a Python script brute forcing it:

```python
import base64

res = set()
for i in range(256):
    for j in range(256):
        for k in range(256):
            data = bytearray([0x50, 0x4b, 0x03, 0x04, i, j, k])
            encoded = base64.b64encode(data).decode('utf-8')[:5]
            if encoded in res:
                continue
            res.add(encoded)
            print(encoded)
```

There's also a whole side-discussion on weither or not ZIP files really always need to start with those particular magic bytes, but let's table that for now. It's happening often enough :-). Oh and the rule also takes advantage of the fact that encoded attachment content is prepended with an entirely empty line. Anyway, here is a generic rule for the start of the above-mentioned infection chain:

```
rule EmailWithZipAttachment {
    meta:
        description = "Some common email headers together with base64 encoded start of a ZIP file"
        author = "@larsborn"
        date = "2024-02-06"
        reference = "https://en.wikipedia.org/wiki/Base64"
        example_hash = "941e4a04ea1ffca986f3ae78f7d0a9bc5483464a679e6ea49a5f4ab8e7e92c03"

        DaysofYARA = "16/100"
    strings:
        $email_headers_01 = "Received: "
        $email_headers_02 = "From: "
        $email_headers_03 = "Date: "
        $email_headers_04 = "Subject: "
        $email_headers_05 = "To: "
        $attachment_headers_01 = "Content-Type: text/html; "
        $attachment_headers_02 = "Content-Type: application/octet-stream; name="
        $attachment_headers_03 = "Content-Disposition: attachment; filename="
        $attachment_headers_04 = "Content-Transfer-Encoding: base64"
        $base64_zip_attachment = { 0d 0a 0d 0a 55 45 73 44 42 }
    condition:
        all of them
}
```