### PR TITLE
Polyglot (JavaScript/Batch) loader stage in a drop-chain resulting in StrelaStealer

### DIFF
--- a/larsborn/Day_018.yara
+++ b/larsborn/Day_018.yara
@@ -1,0 +1,16 @@
+rule PolyglotJavascriptDropper {
+    meta:
+        description = "Polyglot (JavaScript/Batch) loader stage in a drop-chain resulting in StrelaStealer"
+        author = "@larsborn"
+        date = "2023-06-23"
+        reference = "https://medium.com/@avaen/malware-analysis-digital-forensic-strela-stealer-9a3c3402c6bf"
+        reference = "https://youtu.be/MC6SXCJ7pEs?si=U36OXSXeEd7HqPZf&t=900"
+        example_hash = "1b7235d0223274eafd9b93d62cb33908a1af5b3d2c2970e322b3e31ddee5c29a"
+
+        DaysofYARA = "18/100"
+    strings:
+        $ = "*/WScript[\"Cr"
+        $ = "4d 5a 90 00 03 00 00 00"
+    condition:
+        all of them
+}

--- a/larsborn/Day_019.yara
+++ b/larsborn/Day_019.yara
@@ -1,0 +1,17 @@
+rule StrelaStealer_PdbPath {
+    meta:
+        description = "PDB path fragments present in some StrelaStealer samples"
+        author = "@larsborn"
+        date = "2024-02-10"
+        reference = "https://malpedia.caad.fkie.fraunhofer.de/details/win.strelastealer"
+        example_hash = "6e8a3ffffd2f7a91f3f845b78dd90011feb80d30b4fe48cb174b629afa273403"
+        example_hash = "8b0d8651e035fcc91c39b3260c871342d1652c97b37c86f07a561828b652e907"
+
+        DaysofYARA = "19/100"
+    strings:
+        $ = "C:\\Users\\Serhii\\"
+        $ = "\\StrelaDLLCompile\\"
+        $ = "StrelaDLLCompile.pdb"
+    condition:
+        any of them
+}


### PR DESCRIPTION
Almost there: this is the second to last stage of the dropchain I've been ranting about. It is quite a surprising thing though because it's both a valid JScript file as well as a valid Batch file. It's end goal is to execute an embedded DLL with rundll32.exe. In order to do so it is first executed as JS: here it just copies itself with a .bat extension to the temp directory and runs that file which in turn greps itself (`findstr` under Windows) to a new file to strip out all lines not containing the hex-encoded final stage. It then uses certutil to decode that payload and finally rundll32 to call an export named `f` and the resulting DLL.

The rule today is pretty shitty and easily defeated by adding more obfuscation.

—

Now to the boring part, or rather, the part where we do the actual job of classifying the ultimate payload of a drop chain with a static signature. Today, the rule will match on several PDB path fragments observed in StrelaStealer. Easy to evade of course.