### PR TITLE
Compiled Android Manifest

### DIFF
--- a/larsborn/Day_021.yara
+++ b/larsborn/Day_021.yara
@@ -1,0 +1,12 @@
+rule BinaryAndroidManifestXml {
+    meta:
+        description = "Probably a compiled binary manifest from an Android application (i.e. AndroidManifest.xml)"
+        author = "@larsborn"
+        date = "2024-02-10"
+        reference = "https://androguard.readthedocs.io/en/latest/api/androguard.core.bytecodes.html#androguard.core.bytecodes.axml.AXMLParser"
+        example_hash = "503c7b5a752e6112e29b28c74b2989efde2110cbf91c49ac0ea8752204746f06"
+
+        DaysofYARA = "21/100"
+    condition:
+        uint32be(0) == 0x03000800 and uint32(4) == filesize
+}


### PR DESCRIPTION
I'll move over to some generic Android-specific rules: this one matches on the header of compiled manifest files (AndroidManifest.xml). Those start with file magic followed by the file size itself.