### PR TITLE
Java .class file / Kotlin artifact

### DIFF
--- a/larsborn/Day_024.yara
+++ b/larsborn/Day_024.yara
@@ -1,0 +1,18 @@
+rule JavaClass {
+    meta:
+        description = "Java class file with a sane constant pool and the first constant being printable"
+        author = "@larsborn"
+        date = "2024-02-18"
+        reference = "https://en.wikipedia.org/wiki/Java_class_file"
+        example_hash = "158a19eb94aa2f3e2f459db69ee10276c73b945dd6c5f8fc223cf2d85e2b5e33"
+
+        DaysofYARA = "24/100"
+    condition:
+        uint32be(0) == 0xcafebabe
+        and uint16be(6) & 0xff >= 43 // major version
+        and 3 < uint16be(8) and uint16be(8) <= 3000 // sane constant pool count bounds
+        and 3 < uint16be(11) and uint16be(11) <= 300 // sane first constant length
+        and for all i in ( 1 .. uint16be(11) ) : ( // first constant printable
+            0x20 <= (uint16be(11 + i) & 0xff) and (uint16be(11 + i) & 0xff) < 127
+        )
+}

--- a/larsborn/Day_025.yara
+++ b/larsborn/Day_025.yara
@@ -1,0 +1,21 @@
+rule AndroidKotlinDebugProbesKt {
+    meta:
+        description = "Kotlin artifact needed to enable the builtin support for coroutines debugger in IDEA (DebugProbesKt.bin)"
+        author = "@larsborn"
+        date = "2024-02-18"
+        reference = "TODO"
+        example_hash = "158a19eb94aa2f3e2f459db69ee10276c73b945dd6c5f8fc223cf2d85e2b5e33"
+
+        DaysofYARA = "25/100"
+    strings:
+        $constant = "kotlin/coroutines/jvm/internal/DebugProbesKt"
+    condition:
+        uint32be(0) == 0xcafebabe
+        and uint16be(6) & 0xff >= 43 // major version
+        and 3 < uint16be(8) and uint16be(8) <= 3000 // sane constant pool count bounds
+        and uint16be(11) == 44 // length of first constant
+        and for all i in ( 1 .. uint16be(11) ) : ( // first constant printable
+            0x20 <= (uint16be(11 + i) & 0xff) and (uint16be(11 + i) & 0xff) < 127
+        )
+        and $constant at 13
+}


### PR DESCRIPTION
Let's cover more ground in the Android realm: this rule matches on Java .class files while making sure that the constant pool of those files is within sane boundaries. Feel free to negate those checks to find weird .class files instead.

Kotlin is a programming language designed to completely interoperate with JAVA and the JVM. It is often used within Android applications and this rule matches on the file name `DebugProbesKt.bin` within an Android application which seems to be characteristic for Kotlin.