### PR TITLE
OpenType font files

### DIFF
--- a/larsborn/Day_025.yara
+++ b/larsborn/Day_025.yara
@@ -3,7 +3,7 @@ rule AndroidKotlinDebugProbesKt {
         description = "Kotlin artifact needed to enable the builtin support for coroutines debugger in IDEA (DebugProbesKt.bin)"
         author = "@larsborn"
         date = "2024-02-18"
-        reference = "TODO"
+        reference = "https://github.com/Kotlin/kotlinx.coroutines/issues/2274"
         example_hash = "158a19eb94aa2f3e2f459db69ee10276c73b945dd6c5f8fc223cf2d85e2b5e33"
 
         DaysofYARA = "25/100"

--- a/larsborn/Day_026.yara
+++ b/larsborn/Day_026.yara
@@ -1,0 +1,14 @@
+rule OpenTypeFontFile {
+    meta:
+        description = "Generic signature for the OpenType font format, excludes some unexpected but valid files to reduce false-positive rate"
+        author = "@larsborn"
+        date = "2024-03-10"
+        reference = "https://en.wikipedia.org/wiki/OpenType"
+        example_hash = "09bcc57b0f2b1518758831018922eadb2b3f279b56d13e1ba9aae04c1927a763"
+
+        DaysofYARA = "26/100"
+    condition:
+        uint32be(0) == 0x4f54544f // OTTO
+        and 4 < uint16be(4) and uint16be(4) < 100 // sensible range for table count
+        and uint16be(6) & 0xf == 0 // search range is often divisible by 16
+}


### PR DESCRIPTION
In search for some inspiration, I scrolled through https://www.garykessler.net/library/file_sigs.html and font files piqued my interest. I'll start with a generic rule for the OpenType font format. It is, as one might expect starting with "Open" and all, a registered trademark of Microsoft. This signature matches on the file magic and then puts some sensible boundaries in place that I've observed in font files on my local installation.